### PR TITLE
fix: avoid kernel panic after exiting shell [Ji Zeng]

### DIFF
--- a/src/2-environment-preparation.tex
+++ b/src/2-environment-preparation.tex
@@ -50,7 +50,7 @@ make -j$(nproc)
 \subsection{Linux内核编译}
 \begin{lstlisting}[language=bash]
 # 安装依赖
-sudo apt-get install git fakeroot build-essential ncurses-dev xz-utils libssl-dev bc flex libelf-dev bison 
+sudo apt-get install git fakeroot build-essential ncurses-dev xz-utils libssl-dev bc flex libelf-dev bison
 mkdir ~/kernel && cd ~/kernel
 wget https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot/linux-5.x.x.tar.gz
 tar -xf linux-5.x.x.tar.gz
@@ -138,7 +138,16 @@ build
 \begin{lstlisting}[language=bash, language=bash, showstringspaces=false]
 cd busybox-1.x.x/_install/
 mkdir -p proc sys dev tmp
-echo -e '#!/bin/sh\nmount -t proc none /proc\nmount -t sysfs none /sys\nmount -t tmpfs none /tmp\nmount -t devtmpfs none /dev\necho "Hello Linux!"\nexec /bin/sh' > init
+cat > init << 'EOF'
+#!/bin/sh
+mount -t proc none /proc
+mount -t sysfs none /sys
+mount -t tmpfs none /tmp
+mount -t devtmpfs none /dev
+echo "Hello Linux!"
+sh
+poweroff -f
+EOF
 chmod +x init
 \end{lstlisting}
 


### PR DESCRIPTION
avoid kernel panic after exiting shell by shutting the VM done manually.